### PR TITLE
Fixed an issue where a node prefix was ignored and the node was not v…

### DIFF
--- a/codevalidator-api/pom.xml
+++ b/codevalidator-api/pom.xml
@@ -107,28 +107,6 @@
 					<target>1.7</target>
 				</configuration>
 			</plugin>
-
-			<plugin>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.2.2.v20140723</version>
-				<configuration>
-					<scanIntervalSeconds>3</scanIntervalSeconds>
-					<useTestScope>true</useTestScope>
-					<jvmArgs>-Xmx2024m -Xms2024m -XX:PermSize=256m -XX:MaxPermSize=512m</jvmArgs>
-					<webApp>
-						<contextPath>/</contextPath>
-					</webApp>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.hsqldb</groupId>
-						<artifactId>hsqldb</artifactId>
-						<version>2.3.3</version>
-						<scope>runtime</scope>
-					</dependency>
-				</dependencies>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/codevalidator-api/src/main/java/org/sitenv/vocabularies/configuration/CodeValidatorApiConfiguration.java
+++ b/codevalidator-api/src/main/java/org/sitenv/vocabularies/configuration/CodeValidatorApiConfiguration.java
@@ -166,6 +166,7 @@ public class CodeValidatorApiConfiguration {
     @Bean
     public DocumentBuilder documentBuilder() throws ParserConfigurationException {
         DocumentBuilderFactory domFactory =  DocumentBuilderFactory.newInstance();
+        domFactory.setNamespaceAware(true);
         return domFactory.newDocumentBuilder();
     }
 

--- a/codevalidator-api/src/main/java/org/sitenv/vocabularies/validation/utils/CCDADocumentNamespaces.java
+++ b/codevalidator-api/src/main/java/org/sitenv/vocabularies/validation/utils/CCDADocumentNamespaces.java
@@ -1,0 +1,18 @@
+package org.sitenv.vocabularies.validation.utils;
+
+public enum CCDADocumentNamespaces {
+    sdtc ("urn:hl7-org:sdtc"),
+    v3 ("urn:hl7-org:v3"),
+    defaultNameSpaceForCcda ("urn:hl7-org:v3"),
+    voc ("urn:hl7-org:v3/voc");
+
+    private final String namespace;
+
+    CCDADocumentNamespaces(final String namespace) {
+        this.namespace = namespace;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+}


### PR DESCRIPTION
…alidated, or an incorrect node with the same name was validated. Did this by enabling namespace aware and updating xpath expressions to use proper prefixes.